### PR TITLE
changed iconPack to iconpack

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -134,7 +134,7 @@
         "version": 0,
         "unreadBadgeColor": "#bf616a",
         "mentionLineColor": "#CEC174",
-        "iconPack": "rosiecord-plumpy",
+        "iconpack": "rosiecord-plumpy",
         "icons": {
             "ic_new_pins": [
                 "#FAE2AC"


### PR DESCRIPTION
Fixes the icon pack not working. `iconPack` was indicated in documentation but wasn't correct. `iconpack` without capitalization ended up working.